### PR TITLE
use git pull --ff-only for environment checkouts

### DIFF
--- a/pet.py
+++ b/pet.py
@@ -113,7 +113,7 @@ class PuppetInstance(object):
       msg = "UPDATE %s from %s to %s" % (env, old_rev[:7], new_rev[:7])
       syslog(LOG_NOTICE, msg)
       print(msg)
-      cmd = [self.git, 'pull', '--quiet', self.remote_cache_path, env]
+      cmd = [self.git, 'pull', '--ff-only', '--quiet', self.remote_cache_path, env]
       check_call(cmd, cwd=envpath)
       cmd = [self.git, 'diff', '--name-only', old_rev, new_rev, '--', 'Puppetfile.lock']
       output = check_output(cmd, cwd=envpath)


### PR DESCRIPTION
Hi Scott. Hope you are well. :)

I noticed pet was making some merge commits a while back. Not sure what the cause was, but hopefully this will make it more evident when it happens. I thought I'd send this patch your way.

---

The pet environment checkouts and pet cache repository should have never
diverged, so if a merge commit would have been introduced by `git pull` then
something is probably the matter and needs to be resolved manually.

This means people can't go `git commit`-ing in /etc/puppet/environments, but
that's probably a bad thing to do anyway.
